### PR TITLE
Add advanced PDF merge and split examples

### DIFF
--- a/examples/working_with_documents/example_merge_pdf_document.py
+++ b/examples/working_with_documents/example_merge_pdf_document.py
@@ -45,6 +45,159 @@ def merge_two_documents(infile1, infile2, outfile):
     document1.save(outfile)
 
 
+def _append_page_range(source_document, destination_document, start_page, end_page):
+    total_pages = len(source_document.pages)
+    if total_pages == 0:
+        return
+
+    start = max(1, start_page)
+    end = min(end_page, total_pages)
+    if start > end:
+        return
+
+    for page_number in range(start, end + 1):
+        destination_document.pages.add(source_document.pages[page_number])
+
+
+def merge_multiple_documents(input_files, outfile):
+    """Merge multiple input PDF documents into one output PDF.
+
+    Args:
+        input_files (list[str]): Ordered list of PDF file paths to merge.
+        outfile (str): Path where the merged PDF will be saved.
+    Returns:
+        None
+    """
+    output_document = ap.Document()
+
+    for input_file in input_files:
+        source_document = ap.Document(input_file)
+        _append_page_range(source_document, output_document, 1, len(source_document.pages))
+
+    output_document.save(outfile)
+
+
+def merge_selected_page_ranges(infile1, infile2, outfile):
+    """Merge selected page ranges from two PDF documents.
+
+    This example appends pages 1-2 from the first document, then pages 2-3
+    from the second document. Ranges are clamped to available page counts.
+
+    Args:
+        infile1 (str): Path to first input PDF.
+        infile2 (str): Path to second input PDF.
+        outfile (str): Path where the merged PDF will be saved.
+    Returns:
+        None
+    """
+    document1 = ap.Document(infile1)
+    document2 = ap.Document(infile2)
+    output_document = ap.Document()
+
+    _append_page_range(document1, output_document, 1, 2)
+    _append_page_range(document2, output_document, 2, 3)
+
+    output_document.save(outfile)
+
+
+def merge_insert_document_at_position(infile1, infile2, insert_after_page, outfile):
+    """Insert one document into another after a given page index.
+
+    Args:
+        infile1 (str): Base PDF file path.
+        infile2 (str): PDF file path to insert into the base document.
+        insert_after_page (int): Insert after this 1-based page number.
+        outfile (str): Path where the merged PDF will be saved.
+    Returns:
+        None
+    """
+    base_document = ap.Document(infile1)
+    insert_document = ap.Document(infile2)
+    output_document = ap.Document()
+
+    base_total_pages = len(base_document.pages)
+    insert_index = max(0, min(insert_after_page, base_total_pages))
+
+    _append_page_range(base_document, output_document, 1, insert_index)
+    _append_page_range(insert_document, output_document, 1, len(insert_document.pages))
+    _append_page_range(base_document, output_document, insert_index + 1, base_total_pages)
+
+    output_document.save(outfile)
+
+
+def merge_alternating_pages(infile1, infile2, outfile):
+    """Merge two documents by alternating pages from each source.
+
+    If page counts differ, remaining pages from the longer document are
+    appended at the end in their original order.
+
+    Args:
+        infile1 (str): Path to first input PDF.
+        infile2 (str): Path to second input PDF.
+        outfile (str): Path where the merged PDF will be saved.
+    Returns:
+        None
+    """
+    document1 = ap.Document(infile1)
+    document2 = ap.Document(infile2)
+    output_document = ap.Document()
+
+    document1_pages = len(document1.pages)
+    document2_pages = len(document2.pages)
+    max_pages = max(document1_pages, document2_pages)
+
+    for page_number in range(1, max_pages + 1):
+        if page_number <= document1_pages:
+            output_document.pages.add(document1.pages[page_number])
+        if page_number <= document2_pages:
+            output_document.pages.add(document2.pages[page_number])
+
+    output_document.save(outfile)
+
+
+def merge_with_section_separators_and_bookmarks(input_files, outfile):
+    """Merge documents with separator pages and section bookmarks.
+
+    A separator page is inserted before each source document. A top-level
+    section bookmark points to the separator page, and a child bookmark
+    points to the first content page of that merged section.
+
+    Args:
+        input_files (list[str]): Ordered list of PDF file paths to merge.
+        outfile (str): Path where the merged PDF will be saved.
+    Returns:
+        None
+    """
+    output_document = ap.Document()
+
+    for section_index, input_file in enumerate(input_files, start=1):
+        source_document = ap.Document(input_file)
+        source_page_count = len(source_document.pages)
+
+        separator_page = output_document.pages.add()
+        separator_page.paragraphs.add(
+            ap.text.TextFragment(f"Section {section_index}: {path.basename(input_file)}")
+        )
+
+        section_bookmark = ap.OutlineItemCollection(output_document.outlines)
+        section_bookmark.title = f"Section {section_index}"
+        section_bookmark.action = ap.annotations.GoToAction(separator_page)
+        output_document.outlines.append(section_bookmark)
+
+        first_content_page_number = len(output_document.pages) + 1
+        _append_page_range(source_document, output_document, 1, source_page_count)
+
+        if source_page_count > 0 and first_content_page_number <= len(output_document.pages):
+            content_bookmark = ap.OutlineItemCollection(output_document.outlines)
+            content_bookmark.title = f"Section {section_index} Content"
+            content_bookmark.action = ap.annotations.GoToAction(
+                output_document.pages[first_content_page_number]
+            )
+            section_bookmark.append(content_bookmark)
+
+    output_document.save(outfile)
+
+
 def run_all_examples(data_dir=None, license_path=None):
     """Run Merge Document examples and report status.
     Args:
@@ -58,15 +211,34 @@ def run_all_examples(data_dir=None, license_path=None):
     input_dir, output_dir = initialize_data_dir(data_dir)
 
     examples = [
-        ("Merge two documents", merge_two_documents),
+        ("Merge two documents", merge_two_documents, "sample_merge_two_documents.pdf"),
+        ("Merge multiple documents", merge_multiple_documents, "sample_merge_multiple_documents.pdf"),
+        ("Merge selected page ranges", merge_selected_page_ranges, "sample_merge_selected_ranges.pdf"),
+        ("Merge with inserted document", merge_insert_document_at_position, "sample_merge_insert_position.pdf"),
+        ("Merge alternating pages", merge_alternating_pages, "sample_merge_alternating_pages.pdf"),
+        (
+            "Merge with section separators and bookmarks",
+            merge_with_section_separators_and_bookmarks,
+            "sample_merge_sections_bookmarks.pdf",
+        ),
     ]
 
-    for name, func in examples:
+    for name, func, output_file in examples:
         try:
             input_file_name1 = path.join(input_dir, "sample1.pdf")
             input_file_name2 = path.join(input_dir, "sample3.pdf")
-            output_file_name = path.join(output_dir, "sample_merge.pdf")
-            func(input_file_name1, input_file_name2, output_file_name)
+            input_file_name3 = path.join(input_dir, "sample2.pdf")
+            output_file_name = path.join(output_dir, output_file)
+
+            if func is merge_multiple_documents:
+                func([input_file_name1, input_file_name2, input_file_name3], output_file_name)
+            elif func is merge_with_section_separators_and_bookmarks:
+                func([input_file_name1, input_file_name2, input_file_name3], output_file_name)
+            elif func is merge_insert_document_at_position:
+                func(input_file_name1, input_file_name2, 2, output_file_name)
+            else:
+                func(input_file_name1, input_file_name2, output_file_name)
+
             print(f"✅ Success: {name}")
         except Exception as e:
             print(f"❌ Failed: {name} - {str(e)}")

--- a/examples/working_with_documents/example_split_pdf_document.py
+++ b/examples/working_with_documents/example_split_pdf_document.py
@@ -8,35 +8,170 @@ from config import set_license, initialize_data_dir
 
 
 def split_documents(infile, outdir):
-    """Split a multi-page PDF document into separate single-page documents.
-
-    Each page from the input PDF is saved as an individual PDF file in the
-    specified output directory using the naming pattern ``Page_{n}.pdf``,
-    where ``n`` is the 1-based page index.
-
-    Args:
-        infile (str): Path to the source multi-page PDF file to split.
-        outdir (str): Directory where the single-page PDF files will be created.
-
-    Returns:
-        None
-
-    Examples:
-        Split ``sample_split.pdf`` into individual page files in the output directory:
-
-        >>> from os import path
-        >>> from examples.working_with_documents.example_split_pdf_document import split_documents
-        >>> input_file = path.join("sample_data", "input", "sample_split.pdf")
-        >>> output_dir = path.join("sample_data", "output")
-        >>> split_documents(input_file, output_dir)
-    """
     document = ap.Document(infile)
-    page_count = 1
-    for page in document.pages:
-        with ap.Document(infile) as new_document:
-            new_document.pages.add(page)
-            new_document.save(path.join(outdir, f"Page_{page_count}.pdf"))
-            page_count += 1
+    for page_num in range(1, len(document.pages) + 1):
+        with ap.Document() as new_document:
+            new_document.pages.add(document.pages[page_num])
+            new_document.save(path.join(outdir, f"Page_{page_num}.pdf"))
+
+def split_documents_into_two_parts(infile, outdir):
+    document = ap.Document(infile)
+    total_pages = len(document.pages)
+    mid_point = total_pages // 2
+
+    # First part    
+    with ap.Document(infile) as first_document:
+        first_part_range = range(mid_point + 1, total_pages + 1)
+        first_document.pages.delete(first_part_range)
+        first_document.save(path.join(outdir, "Part_1.pdf"))
+
+    # Second part
+    with ap.Document(infile) as second_document:
+        second_part_range = range(1, mid_point + 1)
+        second_document.pages.delete(second_part_range) 
+        second_document.save(path.join(outdir, "Part_2.pdf"))
+
+
+def split_documents_every_n_pages(infile, outdir, pages_per_part=3):
+    document = ap.Document(infile)
+    total_pages = len(document.pages)
+
+    part_index = 1
+    for start_page in range(1, total_pages + 1, pages_per_part):
+        end_page = min(start_page + pages_per_part - 1, total_pages)
+
+        with ap.Document() as part_document:
+            for page_num in range(start_page, end_page + 1):
+                part_document.pages.add(document.pages[page_num])
+            part_document.save(path.join(outdir, f"Every_{pages_per_part}_Part_{part_index}.pdf"))
+
+        part_index += 1
+
+
+def split_documents_by_page_ranges(infile, outdir):
+    document = ap.Document(infile)
+    total_pages = len(document.pages)
+    # Define ranges as (start_page, end_page). Use None to indicate last page.
+    ranges = [(1, 3), (4, 6), (7, None)]
+
+    for index, (start_page, end_page) in enumerate(ranges, start=1):
+        if start_page > total_pages:
+            continue
+
+        effective_end = total_pages if end_page is None else min(end_page, total_pages)
+        if start_page > effective_end:
+            continue
+
+        with ap.Document() as range_document:
+            for page_num in range(start_page, effective_end + 1):
+                range_document.pages.add(document.pages[page_num])
+            range_document.save(path.join(outdir, f"Range_{index}_{start_page}_to_{effective_end}.pdf"))
+
+
+def split_documents_first_page_and_rest(infile, outdir):
+    document = ap.Document(infile)
+    total_pages = len(document.pages)
+
+    if total_pages == 0:
+        return
+
+    with ap.Document() as first_page_document:
+        first_page_document.pages.add(document.pages[1])
+        first_page_document.save(path.join(outdir, "First_Page.pdf"))
+
+    if total_pages == 1:
+        return
+
+    with ap.Document() as remaining_pages_document:
+        for page_num in range(2, total_pages + 1):
+            remaining_pages_document.pages.add(document.pages[page_num])
+        remaining_pages_document.save(path.join(outdir, "Remaining_Pages.pdf"))
+
+
+def split_documents_last_page_and_rest(infile, outdir):
+    document = ap.Document(infile)
+    total_pages = len(document.pages)
+
+    if total_pages == 0:
+        return
+
+    with ap.Document() as last_page_document:
+        last_page_document.pages.add(document.pages[total_pages])
+        last_page_document.save(path.join(outdir, "Last_Page.pdf"))
+
+    if total_pages == 1:
+        return
+
+    document.pages.delete(total_pages)  # Remove last page from original document
+    document.save(path.join(outdir, "Previous_Pages.pdf"))
+
+
+def split_documents_into_three_parts(infile, outdir):
+    document = ap.Document(infile)
+    total_pages = len(document.pages)
+
+    if total_pages == 0:
+        return
+
+    part_size = max(1, (total_pages + 2) // 3)
+
+    for part_index in range(3):
+        start_page = part_index * part_size + 1
+        end_page = min((part_index + 1) * part_size, total_pages)
+
+        if start_page > total_pages:
+            break
+
+        with ap.Document() as part_document:
+            for page_num in range(start_page, end_page + 1):
+                part_document.pages.add(document.pages[page_num])
+            part_document.save(path.join(outdir, f"Three_Parts_{part_index + 1}.pdf"))
+
+
+def split_documents_custom_page_groups(infile, outdir):
+    document = ap.Document(infile)
+    total_pages = len(document.pages)
+    groups = [
+        [1, 2, 5],
+        [3, 4, 6, 7],
+    ]
+
+    for group_index, group in enumerate(groups, start=1):
+        valid_pages = [page_num for page_num in group if 1 <= page_num <= total_pages]
+        if not valid_pages:
+            continue
+
+        with ap.Document() as group_document:
+            for page_num in valid_pages:
+                group_document.pages.add(document.pages[page_num])
+            group_document.save(path.join(outdir, f"Custom_Group_{group_index}.pdf"))
+
+
+def split_documents_with_stable_filenames(infile, outdir):
+    document = ap.Document(infile)
+    total_pages = len(document.pages)
+
+    for page_num in range(1, total_pages + 1):
+        with ap.Document() as new_document:
+            new_document.pages.add(document.pages[page_num])
+            new_document.save(path.join(outdir, f"Page_{page_num:03d}.pdf"))
+
+
+def split_documents_odd_even_pages(infile, outdir):
+    document = ap.Document(infile)
+    total_pages = len(document.pages)
+    
+    # Odd pages document
+    with ap.Document(infile) as document:
+        with ap.Document() as odd_document:
+            for page_num in range(1, total_pages + 1, 2):
+                odd_document.pages.add(document.pages[page_num])
+            odd_document.save(path.join(outdir, "Odd_Pages.pdf"))
+
+        with ap.Document() as even_document:
+            for page_num in range(2, total_pages + 1, 2):
+                even_document.pages.add(document.pages[page_num])          
+            even_document.save(path.join(outdir, "Even_Pages.pdf"))
 
 
 def run_all_examples(data_dir=None, license_path=None):
@@ -53,6 +188,16 @@ def run_all_examples(data_dir=None, license_path=None):
 
     examples = [
         ("Split documents into single pages", split_documents),
+        ("Split documents into two parts", split_documents_into_two_parts),
+        ("Split documents into odd and even pages", split_documents_odd_even_pages),
+        ("Split documents every N pages", split_documents_every_n_pages),
+        ("Split documents by page ranges", split_documents_by_page_ranges),
+        ("Split first page and remaining pages", split_documents_first_page_and_rest),
+        ("Split last page and remaining pages", split_documents_last_page_and_rest),
+        ("Split documents into three parts", split_documents_into_three_parts),
+        ("Split documents by custom page groups", split_documents_custom_page_groups),
+        ("Split documents with stable filenames", split_documents_with_stable_filenames),
+
     ]
 
     for name, func in examples:


### PR DESCRIPTION
Introduce multiple new utilities and examples for PDF merging and splitting. Adds _append_page_range helper and several merge functions (merge_multiple_documents, merge_selected_page_ranges, merge_insert_document_at_position, merge_alternating_pages, merge_with_section_separators_and_bookmarks) with range clamping, insertion, alternating pages, separators and bookmarks. Expands split examples with many strategies (two/three parts, every-N pages, page ranges, first/last vs rest, odd/even, custom groups, stable zero-padded filenames) and replaces the simple single-page split implementation. Update run_all_examples in both files to register and dispatch the new example variants and generate descriptive output filenames.